### PR TITLE
feat: using oxc transfomer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
-  Continuous Releases:
+  Continuous-Releases:
     timeout-minutes: 20
     name: "Continuous Releases"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
   Continuous Releases:
     timeout-minutes: 20
     name: "Continuous Releases"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ env:
 
 on:
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 
@@ -82,6 +80,9 @@ jobs:
       - name: Test build
         run: pnpm run test-build
 
+      - name: Continuous Releases
+        run: pnpx pkg-pr-new publish
+
   lint:
     if: github.repository == 'vitejs/vite-plugin-react'
     timeout-minutes: 10
@@ -115,3 +116,28 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+  Continuous Releases:
+    timeout-minutes: 20
+    name: "Continuous Releases"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.0.0
+
+      - name: Set node version to 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Continuous Releases
+        run: pnpx pkg-pr-new publish --pnpm ./packages/plugin-react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ env:
 
 on:
   push:
+    branches:
+      - using-oxc-transfomer
   pull_request:
   workflow_dispatch:
 
@@ -79,9 +81,6 @@ jobs:
 
       - name: Test build
         run: pnpm run test-build
-
-      - name: Continuous Releases
-        run: pnpx pkg-pr-new publish
 
   lint:
     if: github.repository == 'vitejs/vite-plugin-react'

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "vite": "^5.4.8",
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@43",
     "vitest": "^2.1.1"
   },
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@f6f9fbe",
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@3a82b11",
     "vitest": "^2.1.1"
   },
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
-    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@43",
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@f6f9fbe",
     "vitest": "^2.1.1"
   },
   "simple-git-hooks": {

--- a/packages/plugin-react/build.config.ts
+++ b/packages/plugin-react/build.config.ts
@@ -2,7 +2,7 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   entries: ['src/index'],
-  externals: ['vite'],
+  externals: ['rolldown-vite'],
   clean: true,
   declaration: true,
   rollup: {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -38,14 +38,10 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#readme",
   "dependencies": {
-    "@babel/core": "^7.25.2",
-    "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-    "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-    "@types/babel__core": "^7.20.5",
     "react-refresh": "^0.14.2"
   },
   "peerDependencies": {
-    "vite": "^4.2.0 || ^5.0.0"
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@43"
   },
   "devDependencies": {
     "unbuild": "^2.0.0"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -41,7 +41,7 @@
     "react-refresh": "^0.14.2"
   },
   "peerDependencies": {
-    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@43"
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@f6f9fbe"
   },
   "devDependencies": {
     "unbuild": "^2.0.0"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitejs/plugin-react",
+  "name": "rolldown-vite-plugin-react",
   "version": "4.3.2",
   "license": "MIT",
   "author": "Evan You",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -41,7 +41,7 @@
     "react-refresh": "^0.14.2"
   },
   "peerDependencies": {
-    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@f6f9fbe"
+    "rolldown-vite": "https://pkg.pr.new/rolldown/vite@3a82b11"
   },
   "devDependencies": {
     "unbuild": "^2.0.0"

--- a/packages/plugin-react/src/babel.d.ts
+++ b/packages/plugin-react/src/babel.d.ts
@@ -1,3 +1,0 @@
-declare module '@babel/plugin-transform-react-jsx-self'
-declare module '@babel/plugin-transform-react-jsx-source'
-declare module 'react-refresh/babel.js'

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,15 +1,10 @@
-// eslint-disable-next-line import/no-duplicates
-import type * as babelCore from '@babel/core'
-// eslint-disable-next-line import/no-duplicates
-import type { ParserOptions, TransformOptions } from '@babel/core'
-import { createFilter } from 'vite'
+import { createFilter } from 'rolldown-vite'
 import type {
   BuildOptions,
   Plugin,
   PluginOption,
-  ResolvedConfig,
   UserConfig,
-} from 'vite'
+} from 'rolldown-vite'
 import {
   addClassComponentRefreshWrapper,
   addRefreshWrapper,
@@ -17,15 +12,6 @@ import {
   runtimeCode,
   runtimePublicPath,
 } from './fast-refresh'
-
-// lazy load babel since it's not used during build if plugins are not used
-let babel: typeof babelCore | undefined
-async function loadBabel() {
-  if (!babel) {
-    babel = await import('@babel/core')
-  }
-  return babel
-}
 
 export interface Options {
   include?: string | RegExp | Array<string | RegExp>
@@ -41,56 +27,11 @@ export interface Options {
    * @default "automatic"
    */
   jsxRuntime?: 'classic' | 'automatic'
-  /**
-   * Babel configuration applied in both dev and prod.
-   */
-  babel?:
-    | BabelOptions
-    | ((id: string, options: { ssr?: boolean }) => BabelOptions)
-}
-
-export type BabelOptions = Omit<
-  TransformOptions,
-  | 'ast'
-  | 'filename'
-  | 'root'
-  | 'sourceFileName'
-  | 'sourceMaps'
-  | 'inputSourceMap'
->
-
-/**
- * The object type used by the `options` passed to plugins with
- * an `api.reactBabel` method.
- */
-export interface ReactBabelOptions extends BabelOptions {
-  plugins: Extract<BabelOptions['plugins'], any[]>
-  presets: Extract<BabelOptions['presets'], any[]>
-  overrides: Extract<BabelOptions['overrides'], any[]>
-  parserOpts: ParserOptions & {
-    plugins: Extract<ParserOptions['plugins'], any[]>
-  }
-}
-
-type ReactBabelHook = (
-  babelConfig: ReactBabelOptions,
-  context: ReactBabelHookContext,
-  config: ResolvedConfig,
-) => void
-
-type ReactBabelHookContext = { ssr: boolean; id: string }
-
-export type ViteReactPluginApi = {
-  /**
-   * Manipulate the Babel options of `@vitejs/plugin-react`
-   */
-  reactBabel?: ReactBabelHook
 }
 
 const reactCompRE = /extends\s+(?:React\.)?(?:Pure)?Component/
 const refreshContentRE = /\$Refresh(?:Reg|Sig)\$\(/
 const defaultIncludeRE = /\.[tj]sx?$/
-const tsRE = /\.tsx?$/
 
 export default function viteReact(opts: Options = {}): PluginOption[] {
   // Provide default values for Rollup compat.
@@ -99,13 +40,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const jsxImportSource = opts.jsxImportSource ?? 'react'
   const jsxImportRuntime = `${jsxImportSource}/jsx-runtime`
   const jsxImportDevRuntime = `${jsxImportSource}/jsx-dev-runtime`
-  let isProduction = true
-  let projectRoot = process.cwd()
   let skipFastRefresh = false
-  let runPluginOverrides:
-    | ((options: ReactBabelOptions, context: ReactBabelHookContext) => void)
-    | undefined
-  let staticBabelOptions: ReactBabelOptions | undefined
 
   // Support patterns like:
   // - import * as React from 'react';
@@ -114,54 +49,27 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const importReactRE = /\bimport\s+(?:\*\s+as\s+)?React\b/
 
   const viteBabel: Plugin = {
-    name: 'vite:react-babel',
-    enforce: 'pre',
-    config() {
-      if (opts.jsxRuntime === 'classic') {
-        return {
-          esbuild: {
-            jsx: 'transform',
+    name: 'vite:react',
+    config(config, env) {
+      const runtime = opts.jsxRuntime ?? 'automatic'
+      return {
+        oxc: {
+          jsx: {
+            runtime,
+            importSource: runtime === 'automatic' ? jsxImportSource : undefined,
+            refresh: env.command === 'serve',
+            development: env.command === 'serve',
           },
-        }
-      } else {
-        return {
-          esbuild: {
-            jsx: 'automatic',
-            jsxImportSource: opts.jsxImportSource,
-          },
-          optimizeDeps: { esbuildOptions: { jsx: 'automatic' } },
-        }
+        },
+        // optimizeDeps: { esbuildOptions: { jsx: 'automatic' } },
       }
     },
     configResolved(config) {
       devBase = config.base
-      projectRoot = config.root
-      isProduction = config.isProduction
       skipFastRefresh =
-        isProduction ||
+        config.isProduction ||
         config.command === 'build' ||
         config.server.hmr === false
-
-      if ('jsxPure' in opts) {
-        config.logger.warnOnce(
-          '[@vitejs/plugin-react] jsxPure was removed. You can configure esbuild.jsxSideEffects directly.',
-        )
-      }
-
-      const hooks: ReactBabelHook[] = config.plugins
-        .map((plugin) => plugin.api?.reactBabel)
-        .filter(defined)
-
-      if (hooks.length > 0) {
-        runPluginOverrides = (babelOptions, context) => {
-          hooks.forEach((hook) => hook(babelOptions, context, config))
-        }
-      } else if (typeof opts.babel !== 'function') {
-        // Because hooks and the callback option can mutate the Babel options
-        // we only create static option in this case and re-create them
-        // each time otherwise
-        staticBabelOptions = createBabelOptions(opts.babel)
-      }
     },
     async transform(code, id, options) {
       if (id.includes('/node_modules/')) return
@@ -170,17 +78,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       if (!filter(filepath)) return
 
       const ssr = options?.ssr === true
-      const babelOptions = (() => {
-        if (staticBabelOptions) return staticBabelOptions
-        const newBabelOptions = createBabelOptions(
-          typeof opts.babel === 'function'
-            ? opts.babel(id, { ssr })
-            : opts.babel,
-        )
-        runPluginOverrides?.(newBabelOptions, { id, ssr })
-        return newBabelOptions
-      })()
-      const plugins = [...babelOptions.plugins]
 
       const isJSX = filepath.endsWith('x')
       const useFastRefresh =
@@ -191,79 +88,14 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             ? importReactRE.test(code)
             : code.includes(jsxImportDevRuntime) ||
               code.includes(jsxImportRuntime)))
+
       if (useFastRefresh) {
-        plugins.push([
-          await loadPlugin('react-refresh/babel'),
-          { skipEnvCheck: true },
-        ])
-      }
-
-      if (opts.jsxRuntime === 'classic' && isJSX) {
-        if (!isProduction) {
-          // These development plugins are only needed for the classic runtime.
-          plugins.push(
-            await loadPlugin('@babel/plugin-transform-react-jsx-self'),
-            await loadPlugin('@babel/plugin-transform-react-jsx-source'),
-          )
+        if (refreshContentRE.test(code)) {
+          code = addRefreshWrapper(code, id)
+        } else if (reactCompRE.test(code)) {
+          code = addClassComponentRefreshWrapper(code, id)
         }
-      }
-
-      // Avoid parsing if no special transformation is needed
-      if (
-        !plugins.length &&
-        !babelOptions.presets.length &&
-        !babelOptions.configFile &&
-        !babelOptions.babelrc
-      ) {
-        return
-      }
-
-      const parserPlugins = [...babelOptions.parserOpts.plugins]
-
-      if (!filepath.endsWith('.ts')) {
-        parserPlugins.push('jsx')
-      }
-
-      if (tsRE.test(filepath)) {
-        parserPlugins.push('typescript')
-      }
-
-      const babel = await loadBabel()
-      const result = await babel.transformAsync(code, {
-        ...babelOptions,
-        root: projectRoot,
-        filename: id,
-        sourceFileName: filepath,
-        // Required for esbuild.jsxDev to provide correct line numbers
-        // This crates issues the react compiler because the re-order is too important
-        // People should use @babel/plugin-transform-react-jsx-development to get back good line numbers
-        retainLines: hasCompiler(plugins)
-          ? false
-          : !isProduction && isJSX && opts.jsxRuntime !== 'classic',
-        parserOpts: {
-          ...babelOptions.parserOpts,
-          sourceType: 'module',
-          allowAwaitOutsideFunction: true,
-          plugins: parserPlugins,
-        },
-        generatorOpts: {
-          ...babelOptions.generatorOpts,
-          decoratorsBeforeExport: true,
-        },
-        plugins,
-        sourceMaps: true,
-      })
-
-      if (result) {
-        let code = result.code!
-        if (useFastRefresh) {
-          if (refreshContentRE.test(code)) {
-            code = addRefreshWrapper(code, id)
-          } else if (reactCompRE.test(code)) {
-            code = addClassComponentRefreshWrapper(code, id)
-          }
-        }
-        return { code, map: result.map }
+        return { code }
       }
     },
   }
@@ -272,11 +104,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   // for React 18 while it's `react-dom` for React 17. We'd need to detect
   // what React version the user has installed.
   const dependencies = ['react', jsxImportDevRuntime, jsxImportRuntime]
-  const staticBabelPlugins =
-    typeof opts.babel === 'object' ? opts.babel?.plugins ?? [] : []
-  if (hasCompilerWithDefaultRuntime(staticBabelPlugins)) {
-    dependencies.push('react/compiler-runtime')
-  }
 
   const viteReactRefresh: Plugin = {
     name: 'vite:react-refresh',
@@ -342,56 +169,3 @@ const silenceUseClientWarning = (userConfig: UserConfig): BuildOptions => ({
     },
   },
 })
-
-const loadedPlugin = new Map<string, any>()
-function loadPlugin(path: string): any {
-  const cached = loadedPlugin.get(path)
-  if (cached) return cached
-
-  const promise = import(path).then((module) => {
-    const value = module.default || module
-    loadedPlugin.set(path, value)
-    return value
-  })
-  loadedPlugin.set(path, promise)
-  return promise
-}
-
-function createBabelOptions(rawOptions?: BabelOptions) {
-  const babelOptions = {
-    babelrc: false,
-    configFile: false,
-    ...rawOptions,
-  } as ReactBabelOptions
-
-  babelOptions.plugins ||= []
-  babelOptions.presets ||= []
-  babelOptions.overrides ||= []
-  babelOptions.parserOpts ||= {} as any
-  babelOptions.parserOpts.plugins ||= []
-
-  return babelOptions
-}
-
-function defined<T>(value: T | undefined): value is T {
-  return value !== undefined
-}
-
-function hasCompiler(plugins: ReactBabelOptions['plugins']) {
-  return plugins.some(
-    (p) =>
-      p === 'babel-plugin-react-compiler' ||
-      (Array.isArray(p) && p[0] === 'babel-plugin-react-compiler'),
-  )
-}
-
-// https://gist.github.com/poteto/37c076bf112a07ba39d0e5f0645fec43
-function hasCompilerWithDefaultRuntime(plugins: ReactBabelOptions['plugins']) {
-  return plugins.some(
-    (p) =>
-      p === 'babel-plugin-react-compiler' ||
-      (Array.isArray(p) &&
-        p[0] === 'babel-plugin-react-compiler' &&
-        p[1]?.runtimeModule === undefined),
-  )
-}

--- a/playground/class-components/package.json
+++ b/playground/class-components/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   }
 }

--- a/playground/class-components/vite.config.ts
+++ b/playground/class-components/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({

--- a/playground/class-components/vite.config.ts
+++ b/playground/class-components/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rolldown-vite'
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 
 export default defineConfig({
   server: { port: 8908 /* Should be unique */ },

--- a/playground/compiler-react-18/package.json
+++ b/playground/compiler-react-18/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-react-jsx-development": "^7.24.7",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "workspace:*",
+    "rolldown-vite-plugin-react": "workspace:*",
     "babel-plugin-react-compiler": "^0.0.0-experimental-b12479e-20240926",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"

--- a/playground/compiler-react-18/vite.config.ts
+++ b/playground/compiler-react-18/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 import react from '@vitejs/plugin-react'
 
 // https://gist.github.com/poteto/37c076bf112a07ba39d0e5f0645fec43
@@ -9,14 +9,14 @@ export default defineConfig(({ command }) => {
     server: { port: 8901 /* Should be unique */ },
     plugins: [
       react({
-        babel: {
-          plugins: [
-            [
-              'babel-plugin-react-compiler',
-              { runtimeModule: 'react-compiler-runtime' },
-            ],
-          ],
-        },
+        // babel: {
+        //   plugins: [
+        //     [
+        //       'babel-plugin-react-compiler',
+        //       { runtimeModule: 'react-compiler-runtime' },
+        //     ],
+        //   ],
+        // },
       }),
     ],
   }

--- a/playground/compiler-react-18/vite.config.ts
+++ b/playground/compiler-react-18/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rolldown-vite'
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 
 // https://gist.github.com/poteto/37c076bf112a07ba39d0e5f0645fec43
 

--- a/playground/compiler/package.json
+++ b/playground/compiler/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-transform-react-jsx-development": "^7.24.7",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "workspace:*",
+    "rolldown-vite-plugin-react": "workspace:*",
     "babel-plugin-react-compiler": "^0.0.0-experimental-b12479e-20240926",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"

--- a/playground/compiler/vite.config.ts
+++ b/playground/compiler/vite.config.ts
@@ -1,15 +1,10 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
-  const babelPlugins = [['babel-plugin-react-compiler', {}]]
-  if (command === 'serve') {
-    babelPlugins.push(['@babel/plugin-transform-react-jsx-development', {}])
-  }
-
   return {
     server: { port: 8900 /* Should be unique */ },
-    plugins: [react({ babel: { plugins: babelPlugins } })],
+    plugins: [react()],
   }
 })

--- a/playground/compiler/vite.config.ts
+++ b/playground/compiler/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rolldown-vite'
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {

--- a/playground/mdx/package.json
+++ b/playground/mdx/package.json
@@ -15,6 +15,6 @@
     "@mdx-js/rollup": "^3.0.1",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   }
 }

--- a/playground/mdx/vite.config.ts
+++ b/playground/mdx/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 import react from '@vitejs/plugin-react'
 import mdx from '@mdx-js/rollup'
 

--- a/playground/mdx/vite.config.ts
+++ b/playground/mdx/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rolldown-vite'
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import mdx from '@mdx-js/rollup'
 
 // https://vitejs.dev/config/

--- a/playground/mdx/vite.config.ts
+++ b/playground/mdx/vite.config.ts
@@ -5,8 +5,5 @@ import mdx from '@mdx-js/rollup'
 // https://vitejs.dev/config/
 export default defineConfig({
   server: { port: 8901 /* Should be unique */ },
-  plugins: [
-    { enforce: 'pre', ...mdx() },
-    react({ include: /\.(mdx|md|ts|tsx)$/ }),
-  ],
+  plugins: [{ enforce: 'pre', ...mdx() }, react({ jsxInclude: /\.(mdx|md)$/ })],
 })

--- a/playground/react-classic/package.json
+++ b/playground/react-classic/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   },
   "babel": {
     "presets": [

--- a/playground/react-classic/vite.config.ts
+++ b/playground/react-classic/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react'
-import type { UserConfig } from 'vite'
+import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {
   server: { port: 8903 /* Should be unique */ },

--- a/playground/react-classic/vite.config.ts
+++ b/playground/react-classic/vite.config.ts
@@ -1,4 +1,4 @@
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {

--- a/playground/react-emotion/package.json
+++ b/playground/react-emotion/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-pipeline-operator": "^7.24.7",
     "@emotion/babel-plugin": "^11.12.0",
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   },
   "babel": {
     "presets": [

--- a/playground/react-emotion/vite.config.ts
+++ b/playground/react-emotion/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 
 export default defineConfig({
   server: { port: 8904 /* Should be unique */ },

--- a/playground/react-emotion/vite.config.ts
+++ b/playground/react-emotion/vite.config.ts
@@ -1,4 +1,4 @@
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import { defineConfig } from 'rolldown-vite'
 
 export default defineConfig({

--- a/playground/react-env/package.json
+++ b/playground/react-env/package.json
@@ -13,6 +13,6 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   }
 }

--- a/playground/react-env/vite.config.ts
+++ b/playground/react-env/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react'
-import type { UserConfig } from 'vite'
+import type { UserConfig } from 'rolldown-vite'
 
 // Overriding the NODE_ENV set by vitest
 process.env.NODE_ENV = ''

--- a/playground/react-env/vite.config.ts
+++ b/playground/react-env/vite.config.ts
@@ -1,4 +1,4 @@
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import type { UserConfig } from 'rolldown-vite'
 
 // Overriding the NODE_ENV set by vitest

--- a/playground/react-sourcemap/package.json
+++ b/playground/react-sourcemap/package.json
@@ -15,6 +15,6 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   }
 }

--- a/playground/react-sourcemap/vite.config.ts
+++ b/playground/react-sourcemap/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react'
-import type { UserConfig } from 'vite'
+import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {
   server: { port: 8906 /* Should be unique */ },

--- a/playground/react-sourcemap/vite.config.ts
+++ b/playground/react-sourcemap/vite.config.ts
@@ -1,4 +1,4 @@
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -116,7 +116,8 @@ if (!isBuild) {
     )
   })
 
-  test('should hmr files with "react/jsx-runtime"', async () => {
+  // ref https://github.com/oxc-project/oxc/issues/6620
+  test.skip('should hmr files with "react/jsx-runtime"', async () => {
     expect(await page.textContent('#state-button')).toMatch('count is: 0')
     await page.click('#state-button')
     expect(await page.textContent('#state-button')).toMatch('count is: 1')

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -116,8 +116,7 @@ if (!isBuild) {
     )
   })
 
-  // Could not enable the js file transform by config
-  test.skip('should hmr files with "react/jsx-runtime"', async () => {
+  test('should hmr files with "react/jsx-runtime"', async () => {
     expect(await page.textContent('#state-button')).toMatch('count is: 0')
     await page.click('#state-button')
     expect(await page.textContent('#state-button')).toMatch('count is: 1')

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -116,7 +116,7 @@ if (!isBuild) {
     )
   })
 
-  // ref https://github.com/oxc-project/oxc/issues/6620
+  // Could not enable the js file transform by config
   test.skip('should hmr files with "react/jsx-runtime"', async () => {
     expect(await page.textContent('#state-button')).toMatch('count is: 0')
     await page.click('#state-button')

--- a/playground/react/package.json
+++ b/playground/react/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*"
+    "rolldown-vite-plugin-react": "workspace:*"
   },
   "babel": {
     "presets": [

--- a/playground/react/vite.config.ts
+++ b/playground/react/vite.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react'
-import type { UserConfig } from 'vite'
+import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {
   server: { port: 8902 /* Should be unique */ },

--- a/playground/react/vite.config.ts
+++ b/playground/react/vite.config.ts
@@ -1,4 +1,4 @@
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 import type { UserConfig } from 'rolldown-vite'
 
 const config: UserConfig = {

--- a/playground/ssr-react/__tests__/serve.ts
+++ b/playground/ssr-react/__tests__/serve.ts
@@ -10,7 +10,7 @@ export const port = ports['ssr-react']
 export async function serve(): Promise<{ close(): Promise<void> }> {
   if (isBuild) {
     // build first
-    const { build } = await import('vite')
+    const { build } = await import('rolldown-vite')
     // client build
     await build({
       root: rootDir,

--- a/playground/ssr-react/package.json
+++ b/playground/ssr-react/package.json
@@ -17,7 +17,7 @@
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*",
+    "rolldown-vite-plugin-react": "workspace:*",
     "compression": "^1.7.4",
     "express": "^4.21.0",
     "serve-static": "^1.16.2"

--- a/playground/ssr-react/server.js
+++ b/playground/ssr-react/server.js
@@ -28,7 +28,7 @@ export async function createServer(
   let vite
   if (!isProd) {
     vite = await (
-      await import('vite')
+      await import('rolldown-vite')
     ).createServer({
       root,
       logLevel: isTest ? 'error' : 'info',

--- a/playground/ssr-react/vite.config.js
+++ b/playground/ssr-react/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'rolldown-vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({

--- a/playground/ssr-react/vite.config.js
+++ b/playground/ssr-react/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rolldown-vite'
-import react from '@vitejs/plugin-react'
+import react from 'rolldown-vite-plugin-react'
 
 export default defineConfig({
   server: { port: 8907 /* Should be unique */ },

--- a/playground/vitest.config.e2e.ts
+++ b/playground/vitest.config.e2e.ts
@@ -12,6 +12,11 @@ export default defineConfig({
   test: {
     pool: 'forks',
     include: ['./playground/**/*.spec.[tj]s'],
+    exclude: [
+      './playground/react-emotion/**/*.spec.[tj]s', // the remotion need to transformer
+      './playground/mdx/**/*.spec.[tj]s', // need to find a way to let rolldown-vite internal oxc transformer tread mdx as jsx
+      './playground/ssr-react/**/*.spec.[tj]s', // need to find a way to disable the refresh transformer at ssr
+    ],
     setupFiles: ['./playground/vitestSetup.ts'],
     globalSetup: ['./playground/vitestGlobalSetup.ts'],
     testTimeout: timeout,

--- a/playground/vitest.config.e2e.ts
+++ b/playground/vitest.config.e2e.ts
@@ -14,8 +14,6 @@ export default defineConfig({
     include: ['./playground/**/*.spec.[tj]s'],
     exclude: [
       './playground/react-emotion/**/*.spec.[tj]s', // the remotion need to transformer
-      './playground/mdx/**/*.spec.[tj]s', // need to find a way to let rolldown-vite internal oxc transformer tread mdx as jsx
-      './playground/ssr-react/**/*.spec.[tj]s', // need to find a way to disable the refresh transformer at ssr
     ],
     setupFiles: ['./playground/vitestSetup.ts'],
     globalSetup: ['./playground/vitestGlobalSetup.ts'],

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -11,14 +11,14 @@ import type {
   Rollup,
   UserConfig,
   ViteDevServer,
-} from 'vite'
+} from 'rolldown-vite'
 import {
   build,
   createServer,
   loadConfigFromFile,
   mergeConfig,
   preview,
-} from 'vite'
+} from 'rolldown-vite'
 import type { Browser, Page } from 'playwright-chromium'
 import type { File } from 'vitest'
 import { beforeAll } from 'vitest'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       prettier:
         specifier: ^3.0.3
         version: 3.1.0
+      rolldown-vite:
+        specifier: https://pkg.pr.new/rolldown/vite@43
+        version: vite@https://pkg.pr.new/rolldown/vite@43(@types/node@20.16.10)
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1
@@ -71,27 +74,12 @@ importers:
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
-      vite:
-        specifier: ^5.4.8
-        version: 5.4.8(@types/node@20.16.10)
       vitest:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@20.16.10)
 
   packages/plugin-react:
     dependencies:
-      '@babel/core':
-        specifier: ^7.25.2
-        version: 7.25.2
-      '@babel/plugin-transform-react-jsx-self':
-        specifier: ^7.24.7
-        version: 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-jsx-source':
-        specifier: ^7.24.7
-        version: 7.24.7(@babel/core@7.25.2)
-      '@types/babel__core':
-        specifier: ^7.20.5
-        version: 7.20.5
       react-refresh:
         specifier: ^0.14.2
         version: 0.14.2
@@ -426,16 +414,6 @@ packages:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.23.5':
-    resolution: {integrity: sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.24.5':
-    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.25.6':
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
@@ -465,18 +443,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.24.7':
-    resolution: {integrity: sha512-fOPQYbGSgH0HUp4UJO4sMBFjY6DuWq+2i8rixyUMb3CdGixs/gccURvYOAhajBdKDoGajFr3mUq5rH3phtkGzw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.24.7':
-    resolution: {integrity: sha512-J2z+MWzZHVOemyLweMqngXrgGC42jQ//R0KdxqkIz/OrbVIIlhFI3WigZ5fO+nwFvBlncr4MGapd8vTyc7RPNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx@7.25.2':
     resolution: {integrity: sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==}
     engines: {node: '>=6.9.0'}
@@ -499,10 +465,6 @@ packages:
     resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.23.5':
-    resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.24.5':
     resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
     engines: {node: '>=6.9.0'}
@@ -510,6 +472,15 @@ packages:
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@1.3.1':
+    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
+
+  '@emnapi/runtime@1.3.1':
+    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/wasi-threads@1.0.1':
+    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@emotion/babel-plugin@11.12.0':
     resolution: {integrity: sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==}
@@ -577,6 +548,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.24.0':
+    resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.19.8':
     resolution: {integrity: sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==}
     engines: {node: '>=12'}
@@ -591,6 +568,12 @@ packages:
 
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.0':
+    resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -613,6 +596,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.24.0':
+    resolution: {integrity: sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.19.8':
     resolution: {integrity: sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==}
     engines: {node: '>=12'}
@@ -627,6 +616,12 @@ packages:
 
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.0':
+    resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -649,6 +644,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.19.8':
     resolution: {integrity: sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==}
     engines: {node: '>=12'}
@@ -663,6 +664,12 @@ packages:
 
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -685,6 +692,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.24.0':
+    resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.19.8':
     resolution: {integrity: sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==}
     engines: {node: '>=12'}
@@ -699,6 +712,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.0':
+    resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -721,6 +740,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.19.8':
     resolution: {integrity: sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==}
     engines: {node: '>=12'}
@@ -735,6 +760,12 @@ packages:
 
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.0':
+    resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -757,6 +788,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.0':
+    resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.19.8':
     resolution: {integrity: sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==}
     engines: {node: '>=12'}
@@ -771,6 +808,12 @@ packages:
 
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.0':
+    resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -793,6 +836,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.0':
+    resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.19.8':
     resolution: {integrity: sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==}
     engines: {node: '>=12'}
@@ -807,6 +856,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.0':
+    resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -829,6 +884,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.0':
+    resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.19.8':
     resolution: {integrity: sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==}
     engines: {node: '>=12'}
@@ -843,6 +904,12 @@ packages:
 
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.0':
+    resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -865,6 +932,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.0':
+    resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.19.8':
     resolution: {integrity: sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==}
     engines: {node: '>=12'}
@@ -883,8 +956,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.24.0':
+    resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.24.0':
+    resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -907,6 +992,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.24.0':
+    resolution: {integrity: sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.19.8':
     resolution: {integrity: sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==}
     engines: {node: '>=12'}
@@ -921,6 +1012,12 @@ packages:
 
   '@esbuild/sunos-x64@0.23.1':
     resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.24.0':
+    resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -943,6 +1040,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.19.8':
     resolution: {integrity: sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==}
     engines: {node: '>=12'}
@@ -961,6 +1064,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.0':
+    resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.19.8':
     resolution: {integrity: sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==}
     engines: {node: '>=12'}
@@ -975,6 +1084,12 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.0':
+    resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1046,6 +1161,9 @@ packages:
     peerDependencies:
       rollup: '>=2'
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    resolution: {integrity: sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1061,6 +1179,66 @@ packages:
   '@remix-run/router@1.19.2':
     resolution: {integrity: sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==}
     engines: {node: '>=14.0.0'}
+
+  '@rolldown/binding-darwin-arm64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-arm64@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-arm64@e65437c}
+    version: 0.13.2
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-x64@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-x64@e65437c}
+    version: 0.13.2
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-freebsd-x64@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-freebsd-x64@e65437c}
+    version: 0.13.2
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm-gnueabihf@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm-gnueabihf@e65437c}
+    version: 0.13.2
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-gnu@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-gnu@e65437c}
+    version: 0.13.2
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-musl@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-musl@e65437c}
+    version: 0.13.2
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-gnu@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-gnu@e65437c}
+    version: 0.13.2
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-musl@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-musl@e65437c}
+    version: 0.13.2
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-wasm32-wasi@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-wasm32-wasi@e65437c}
+    version: 0.13.2
+    engines: {node: '>=14.21.3'}
+
+  '@rolldown/binding-win32-arm64-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-arm64-msvc@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-arm64-msvc@e65437c}
+    version: 0.13.2
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-ia32-msvc@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-ia32-msvc@e65437c}
+    version: 0.13.2
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-x64-msvc@e65437c':
+    resolution: {tarball: https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-x64-msvc@e65437c}
+    version: 0.13.2
+    os: [win32]
 
   '@rollup/plugin-alias@5.1.0':
     resolution: {integrity: sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==}
@@ -1203,20 +1381,11 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.6.7':
-    resolution: {integrity: sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.20.4':
-    resolution: {integrity: sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1945,6 +2114,11 @@ packages:
 
   esbuild@0.23.1:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.24.0:
+    resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3419,6 +3593,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rolldown@https://pkg.pr.new/rolldown@e65437c:
+    resolution: {tarball: https://pkg.pr.new/rolldown@e65437c}
+    version: 0.13.2
+    hasBin: true
+
   rollup-plugin-dts@6.1.0:
     resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
     engines: {node: '>=16'}
@@ -3737,6 +3916,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@2.8.0:
+    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
+
   tsx@4.19.1:
     resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
     engines: {node: '>=18.0.0'}
@@ -3883,6 +4065,38 @@ packages:
 
   vite@5.4.8:
     resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vite@https://pkg.pr.new/rolldown/vite@43:
+    resolution: {tarball: https://pkg.pr.new/rolldown/vite@43}
+    version: 6.0.0-beta.3
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -4124,14 +4338,6 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.0
 
-  '@babel/parser@7.23.5':
-    dependencies:
-      '@babel/types': 7.24.5
-
-  '@babel/parser@7.24.5':
-    dependencies:
-      '@babel/types': 7.24.5
-
   '@babel/parser@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
@@ -4158,16 +4364,6 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-react-jsx-self@7.24.7(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-jsx@7.25.2(@babel/core@7.25.2)':
     dependencies:
@@ -4204,12 +4400,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.23.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.1
-      '@babel/helper-validator-identifier': 7.24.5
-      to-fast-properties: 2.0.0
-
   '@babel/types@7.24.5':
     dependencies:
       '@babel/helper-string-parser': 7.24.1
@@ -4221,6 +4411,22 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@emnapi/core@1.3.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.1
+      tslib: 2.8.0
+    optional: true
+
+  '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.0
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.1':
+    dependencies:
+      tslib: 2.8.0
+    optional: true
 
   '@emotion/babel-plugin@11.12.0':
     dependencies:
@@ -4301,6 +4507,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.0':
+    optional: true
+
   '@esbuild/android-arm64@0.19.8':
     optional: true
 
@@ -4308,6 +4517,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.0':
     optional: true
 
   '@esbuild/android-arm@0.19.8':
@@ -4319,6 +4531,9 @@ snapshots:
   '@esbuild/android-arm@0.23.1':
     optional: true
 
+  '@esbuild/android-arm@0.24.0':
+    optional: true
+
   '@esbuild/android-x64@0.19.8':
     optional: true
 
@@ -4326,6 +4541,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.24.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.8':
@@ -4337,6 +4555,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.19.8':
     optional: true
 
@@ -4344,6 +4565,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.8':
@@ -4355,6 +4579,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.19.8':
     optional: true
 
@@ -4362,6 +4589,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
   '@esbuild/linux-arm64@0.19.8':
@@ -4373,6 +4603,9 @@ snapshots:
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.0':
+    optional: true
+
   '@esbuild/linux-arm@0.19.8':
     optional: true
 
@@ -4380,6 +4613,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.0':
     optional: true
 
   '@esbuild/linux-ia32@0.19.8':
@@ -4391,6 +4627,9 @@ snapshots:
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.19.8':
     optional: true
 
@@ -4398,6 +4637,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.8':
@@ -4409,6 +4651,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.19.8':
     optional: true
 
@@ -4416,6 +4661,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.8':
@@ -4427,6 +4675,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.19.8':
     optional: true
 
@@ -4434,6 +4685,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.0':
     optional: true
 
   '@esbuild/linux-x64@0.19.8':
@@ -4445,6 +4699,9 @@ snapshots:
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.24.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.19.8':
     optional: true
 
@@ -4454,7 +4711,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.8':
@@ -4466,6 +4729,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.24.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.8':
     optional: true
 
@@ -4473,6 +4739,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.24.0':
     optional: true
 
   '@esbuild/win32-arm64@0.19.8':
@@ -4484,6 +4753,9 @@ snapshots:
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.24.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.19.8':
     optional: true
 
@@ -4493,6 +4765,9 @@ snapshots:
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.0':
+    optional: true
+
   '@esbuild/win32-x64@0.19.8':
     optional: true
 
@@ -4500,6 +4775,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.1)':
@@ -4602,6 +4880,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    dependencies:
+      '@emnapi/core': 1.3.1
+      '@emnapi/runtime': 1.3.1
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4615,6 +4900,44 @@ snapshots:
       fastq: 1.15.0
 
   '@remix-run/router@1.19.2': {}
+
+  '@rolldown/binding-darwin-arm64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-arm64@e65437c':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-x64@e65437c':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-freebsd-x64@e65437c':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm-gnueabihf@e65437c':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-gnu@e65437c':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-musl@e65437c':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-gnu@e65437c':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-musl@e65437c':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-wasm32-wasi@e65437c':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.5
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-arm64-msvc@e65437c':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-ia32-msvc@e65437c':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-x64-msvc@e65437c':
+    optional: true
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
     dependencies:
@@ -4725,30 +5048,14 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.0
+    optional: true
+
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.5
-
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.23.5
-      '@babel/types': 7.23.5
-      '@types/babel__generator': 7.6.7
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.4
-
-  '@types/babel__generator@7.6.7':
-    dependencies:
-      '@babel/types': 7.24.5
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-
-  '@types/babel__traverse@7.20.4':
-    dependencies:
-      '@babel/types': 7.24.5
 
   '@types/debug@4.1.12':
     dependencies:
@@ -5713,6 +6020,33 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  esbuild@0.24.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.0
+      '@esbuild/android-arm': 0.24.0
+      '@esbuild/android-arm64': 0.24.0
+      '@esbuild/android-x64': 0.24.0
+      '@esbuild/darwin-arm64': 0.24.0
+      '@esbuild/darwin-x64': 0.24.0
+      '@esbuild/freebsd-arm64': 0.24.0
+      '@esbuild/freebsd-x64': 0.24.0
+      '@esbuild/linux-arm': 0.24.0
+      '@esbuild/linux-arm64': 0.24.0
+      '@esbuild/linux-ia32': 0.24.0
+      '@esbuild/linux-loong64': 0.24.0
+      '@esbuild/linux-mips64el': 0.24.0
+      '@esbuild/linux-ppc64': 0.24.0
+      '@esbuild/linux-riscv64': 0.24.0
+      '@esbuild/linux-s390x': 0.24.0
+      '@esbuild/linux-x64': 0.24.0
+      '@esbuild/netbsd-x64': 0.24.0
+      '@esbuild/openbsd-arm64': 0.24.0
+      '@esbuild/openbsd-x64': 0.24.0
+      '@esbuild/sunos-x64': 0.24.0
+      '@esbuild/win32-arm64': 0.24.0
+      '@esbuild/win32-ia32': 0.24.0
+      '@esbuild/win32-x64': 0.24.0
 
   escalade@3.1.1: {}
 
@@ -7481,6 +7815,23 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rolldown@https://pkg.pr.new/rolldown@e65437c:
+    dependencies:
+      zod: 3.23.8
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-arm64@e65437c
+      '@rolldown/binding-darwin-x64': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-darwin-x64@e65437c
+      '@rolldown/binding-freebsd-x64': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-freebsd-x64@e65437c
+      '@rolldown/binding-linux-arm-gnueabihf': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm-gnueabihf@e65437c
+      '@rolldown/binding-linux-arm64-gnu': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-gnu@e65437c
+      '@rolldown/binding-linux-arm64-musl': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-arm64-musl@e65437c
+      '@rolldown/binding-linux-x64-gnu': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-gnu@e65437c
+      '@rolldown/binding-linux-x64-musl': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-linux-x64-musl@e65437c
+      '@rolldown/binding-wasm32-wasi': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-wasm32-wasi@e65437c
+      '@rolldown/binding-win32-arm64-msvc': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-arm64-msvc@e65437c
+      '@rolldown/binding-win32-ia32-msvc': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-ia32-msvc@e65437c
+      '@rolldown/binding-win32-x64-msvc': https://pkg.pr.new/rolldown/rolldown/@rolldown/binding-win32-x64-msvc@e65437c
+
   rollup-plugin-dts@6.1.0(rollup@3.29.4)(typescript@5.6.2):
     dependencies:
       magic-string: 0.30.11
@@ -7826,6 +8177,9 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@2.8.0:
+    optional: true
+
   tsx@4.19.1:
     dependencies:
       esbuild: 0.23.1
@@ -8060,6 +8414,16 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
+      rollup: 4.22.5
+    optionalDependencies:
+      '@types/node': 20.16.10
+      fsevents: 2.3.3
+
+  vite@https://pkg.pr.new/rolldown/vite@43(@types/node@20.16.10):
+    dependencies:
+      esbuild: 0.24.0
+      postcss: 8.4.47
+      rolldown: https://pkg.pr.new/rolldown@e65437c
       rollup: 4.22.5
     optionalDependencies:
       '@types/node': 20.16.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^3.0.3
         version: 3.1.0
       rolldown-vite:
-        specifier: https://pkg.pr.new/rolldown/vite@43
-        version: vite@https://pkg.pr.new/rolldown/vite@43(@types/node@20.16.10)
+        specifier: https://pkg.pr.new/rolldown/vite@f6f9fbe
+        version: vite@https://pkg.pr.new/rolldown/vite@f6f9fbe(@types/node@20.16.10)
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1
@@ -112,7 +112,7 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -134,12 +134,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@vitejs/plugin-react':
-        specifier: workspace:*
-        version: link:../../packages/plugin-react
       babel-plugin-react-compiler:
         specifier: ^0.0.0-experimental-b12479e-20240926
         version: 0.0.0-experimental-b12479e-20240926
+      rolldown-vite-plugin-react:
+        specifier: workspace:*
+        version: link:../../packages/plugin-react
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -168,12 +168,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@vitejs/plugin-react':
-        specifier: workspace:*
-        version: link:../../packages/plugin-react
       babel-plugin-react-compiler:
         specifier: ^0.0.0-experimental-b12479e-20240926
         version: 0.0.0-experimental-b12479e-20240926
+      rolldown-vite-plugin-react:
+        specifier: workspace:*
+        version: link:../../packages/plugin-react
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -205,7 +205,7 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -221,7 +221,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -234,7 +234,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -262,7 +262,7 @@ importers:
       '@emotion/babel-plugin':
         specifier: ^11.12.0
         version: 11.12.0
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -275,7 +275,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -288,7 +288,7 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@vitejs/plugin-react':
+      rolldown-vite-plugin-react:
         specifier: workspace:*
         version: link:../../packages/plugin-react
 
@@ -306,15 +306,15 @@ importers:
         specifier: ^6.26.2
         version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
-      '@vitejs/plugin-react':
-        specifier: workspace:*
-        version: link:../../packages/plugin-react
       compression:
         specifier: ^1.7.4
         version: 1.7.4
       express:
         specifier: ^4.21.0
         version: 4.21.0
+      rolldown-vite-plugin-react:
+        specifier: workspace:*
+        version: link:../../packages/plugin-react
       serve-static:
         specifier: ^1.16.2
         version: 1.16.2
@@ -4094,8 +4094,8 @@ packages:
       terser:
         optional: true
 
-  vite@https://pkg.pr.new/rolldown/vite@43:
-    resolution: {tarball: https://pkg.pr.new/rolldown/vite@43}
+  vite@https://pkg.pr.new/rolldown/vite@f6f9fbe:
+    resolution: {tarball: https://pkg.pr.new/rolldown/vite@f6f9fbe}
     version: 6.0.0-beta.3
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -8419,7 +8419,7 @@ snapshots:
       '@types/node': 20.16.10
       fsevents: 2.3.3
 
-  vite@https://pkg.pr.new/rolldown/vite@43(@types/node@20.16.10):
+  vite@https://pkg.pr.new/rolldown/vite@f6f9fbe(@types/node@20.16.10):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.47

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^3.0.3
         version: 3.1.0
       rolldown-vite:
-        specifier: https://pkg.pr.new/rolldown/vite@f6f9fbe
-        version: vite@https://pkg.pr.new/rolldown/vite@f6f9fbe(@types/node@20.16.10)
+        specifier: https://pkg.pr.new/rolldown/vite@3a82b11
+        version: vite@https://pkg.pr.new/rolldown/vite@3a82b11(@types/node@20.16.10)
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1
@@ -4094,8 +4094,8 @@ packages:
       terser:
         optional: true
 
-  vite@https://pkg.pr.new/rolldown/vite@f6f9fbe:
-    resolution: {tarball: https://pkg.pr.new/rolldown/vite@f6f9fbe}
+  vite@https://pkg.pr.new/rolldown/vite@3a82b11:
+    resolution: {tarball: https://pkg.pr.new/rolldown/vite@3a82b11}
     version: 6.0.0-beta.3
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -8419,7 +8419,7 @@ snapshots:
       '@types/node': 20.16.10
       fsevents: 2.3.3
 
-  vite@https://pkg.pr.new/rolldown/vite@f6f9fbe(@types/node@20.16.10):
+  vite@https://pkg.pr.new/rolldown/vite@3a82b11(@types/node@20.16.10):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.47


### PR DESCRIPTION
The package name changed to `rolldown-vite-plugin-react`.

Here has a `react-emotion` test is failed, because it used `@emotion/babel-plugin`, the oxc transformer hasn't the feature.